### PR TITLE
Fix: removed hippo_gz_msgs from uvms_sim dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.swp
 **/venv/
 *.idea/
+.vscode

--- a/uvms_sim/package.xml
+++ b/uvms_sim/package.xml
@@ -17,7 +17,6 @@
     <depend>gz_math_vendor</depend>
     <depend>gz_transport_vendor</depend>
 
-    <depend>hippo_gz_msgs</depend>
     <depend>hippo_msgs</depend>
     <depend>hippo_control_msgs</depend>
     <depend>alpha_msgs</depend>


### PR DESCRIPTION
hippo_gz_msgs is not used in uvms_sim and also not part of the pre-built packages. Thus, checking for unresolved dependencies leads to errors.